### PR TITLE
replace wpscholar/collection with wpforge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
   "require": {
     "newfold-labs/wp-module-data": "^2.0.0",
     "wpscholar/url": "^1.2",
-    "wp-forge/helpers": "^1.1.0"
+    "wp-forge/helpers": "^1.1.0",
+    "wp-forge/collection": "^1.0"
   }
 }

--- a/includes/NotificationsRepository.php
+++ b/includes/NotificationsRepository.php
@@ -4,7 +4,7 @@ namespace NewFoldLabs\WP\Module\Notifications;
 
 use NewfoldLabs\WP\Module\Data\HiiveConnection;
 use WP_Forge\Helpers\Arr;
-use wpscholar\Collection;
+use WP_Forge\Collection\Collection;
 
 use function NewfoldLabs\WP\ModuleLoader\container;
 
@@ -35,7 +35,7 @@ class NotificationsRepository {
 		$notifications = get_transient( self::TRANSIENT );
 		
 		// load test data TODO REMOVE
-		$notifications = self::get_test_notification_data(); 
+		// $notifications = self::get_test_notification_data(); 
 
 		if ( false === $notifications && true === $fetch_notices ) {
 			$response = wp_remote_get(


### PR DESCRIPTION
This module was assuming package would be available from loader, but we just replaced it so it was missing, updating to wpforge and adding to composer requirements too. comment out the test notification data.