### PR TITLE
add a is-dismissed class when notification is dismissed, 

### DIFF
--- a/assets/js/components/notification/index.js
+++ b/assets/js/components/notification/index.js
@@ -15,6 +15,7 @@ const Notification = ({ id, content, methods, constants, ...props }) => {
 
         const noticeContainer = document.querySelector('[data-id="' + id +'"]');
         if ( noticeContainer ) {
+            noticeContainer.classList.add('is-dismissed');
             methods.apiFetch( {
                 url: `${constants.resturl}/newfold-notifications/v1/notifications/${id}`,
                 method: 'DELETE'


### PR DESCRIPTION
Currently when a notification is dismissed it sends a request to the proxied api in the site, which reaches out to the hiive to alert it that the notice has been dismissed, then once they both resolve it will remove the notice from the screen. This can takes a while compared to what users are used to seeing when we click dismiss.

This will add a class to the notice we can then add a style to at least update the visual giving feedback to the user that they clicked something interactive. Ideally, the class can hide the notice or even animate the opacity. This update only adds the class and we'll leave it up to the plugin to style since we have no styles in the module yet.