### PR TITLE
add test file and fixture

### DIFF
--- a/tests/cypress/fixtures/notifications.json
+++ b/tests/cypress/fixtures/notifications.json
@@ -1,0 +1,66 @@
+[
+    {
+        "id": "test-1",
+        "locations": [
+            {
+                "context": "bluehost-plugin",
+                "pages": "#/settings"
+            }
+        ],
+        "expiration": 2748863456503,
+        "content": "<div class=\"newfold-notice notice notice-success\" style=\"position:relative;\"><p>Notice should only display on plugin app settings page<button type=\"button\" data-action=\"close\" class=\"notice-dismiss\"><span class=\"screen-reader-text\">Dismiss this notice.</span></button><\/p><\/div>"
+    },
+    {
+        "id": "test-2",
+        "locations": [
+            {
+                "context": "bluehost-plugin",
+                "pages": [
+                    "#/home/onboarding",
+                    "#/home"
+                ]
+            }
+        ],
+        "expiration": 2749860279240,
+        "content": "<div class=\"newfold-notice notice notice-error\" style=\"position:relative;\"><p>Here is a plugin notice it should display on home and onboarding screens only! <button type=\"button\" data-action=\"close\" class=\"notice-dismiss\"><span class=\"screen-reader-text\">Dismiss this notice.</span></button><\/p><\/div>"
+    },
+    {
+        "id": "test-3",
+        "locations": [
+            {
+                "context": "bluehost-plugin",
+                "pages": [
+                    "#/marketplace"
+                ]
+            }
+        ],
+        "expiration": 2749860279240,
+        "content": "<div class=\"newfold-notice notice notice-info\" style=\"position:relative;\"><p>Here is a plugin notice it should display on marketplace themes screen only! <button type=\"button\" data-action=\"close\" class=\"notice-dismiss\"><span class=\"screen-reader-text\">Dismiss this notice.</span></button><\/p><\/div>"
+    },
+    {
+        "id": "test-4",
+        "locations": [
+            {
+                "context": "bluehost-plugin",
+                "pages": "all"
+            },
+            {
+                "context": "wp-admin-notice",
+                "pages": "all"
+            }
+        ],
+        "expiration": 2749860279240,
+        "content": "<div class=\"newfold-notice notice notice-warning\" style=\"position:relative;\"><p>Here is a notice it should display everywhere in the app and in wp-admin! <button type=\"button\" data-action=\"close\" class=\"notice-dismiss\"><span class=\"screen-reader-text\">Dismiss this notice.</span></button><\/p><\/div>"
+    },
+    {
+        "id": "test-expired",
+        "locations": [
+            {
+                "context": "bluehost-plugin",
+                "pages": "all"
+            }
+        ],
+        "expiration": 1649860279240,
+        "content": "<div class=\"newfold-notice notice notice-error\" style=\"position:relative;\"><p>Here is an expired notice it should never display anywhere even though it has location `all` <button type=\"button\" data-action=\"close\" class=\"notice-dismiss\"><span class=\"screen-reader-text\">Dismiss this notice.</span></button><\/p><\/div>"
+    }
+]

--- a/tests/cypress/integration/notifications.cy.js
+++ b/tests/cypress/integration/notifications.cy.js
@@ -1,0 +1,106 @@
+// <reference types="Cypress" />
+const notifications = require('../fixtures/notifications.json');
+
+describe('Notifications', () => {
+
+	before(() => {
+
+		cy.intercept({
+			method: 'GET',
+			url: '**newfold-notifications**'
+		}, notifications ).as('notifications');
+
+		cy.visit('/wp-admin/admin.php?page=' + Cypress.env('pluginId') + '#/home', {timeout: 30000});
+		cy.wait('@notifications');
+	});
+
+	it('Is Accessible', () => {
+		cy.injectAxe();
+		cy.wait(1000);
+		cy.checkA11y('.newfold-notifications-wrapper');
+	});
+
+	it('Container Exists in plugin app', () => {
+        cy.get('.newfold-notifications-wrapper').should('have.length', 1);
+	});
+
+    // notification renders in all app for `all`
+	it('Test notification displays in plugin app with `all`', () => {
+        cy.get('.newfold-notifications-wrapper #notification-test-4')
+            .should('be.visible')
+			.should('have.attr', 'data-id')
+			.and('equal', 'test-4');
+        
+        cy.get('.newfold-notifications-wrapper #notification-test-4')
+            .contains('it should display everywhere');
+	});
+
+	// notification renders only on specified app page
+	it('Test notification displays in plugin app for specific page (settings)', () => {
+
+        cy.get('.newfold-notifications-wrapper #notification-test-1')
+			.should('not.exist');
+
+		// cy.visit('/wp-admin/admin.php?page=' + Cypress.env('pluginId') + '#/settings');
+		cy.get('.wppbh-app-navitem-Settings').click();
+		cy.wait(500);
+
+        cy.get('.newfold-notifications-wrapper #notification-test-1')
+			.scrollIntoView()
+            .should('be.visible')
+			.should('have.attr', 'data-id')
+			.and('equal', 'test-1');
+        
+        cy.get('.newfold-notifications-wrapper #notification-test-1')
+            .contains('display on plugin app settings page');
+	});
+
+    // expired notification should not show
+	it('Test expired notification does not display in plugin app', () => {
+        cy.get('.newfold-notifications-wrapper #notification-test-expired')
+			.should('not.exist');
+	});
+
+    // dismiss events triggered
+	it('Dismissing notification removes it from the page', () => {
+		cy.intercept({
+			method: 'DELETE',
+			url: /newfold-notifications(\/|%2F)v1(\/|%2F)notifications/
+		}, {
+			body: {"id":"test-2"}
+		}).as('notificationDismiss');
+
+		cy.visit('/wp-admin/admin.php?page=' + Cypress.env('pluginId') + '#/home');
+
+        cy.get('.newfold-notifications-wrapper #notification-test-2')
+			.scrollIntoView()
+            .should('be.visible')
+			.should('have.attr', 'data-id')
+			.and('equal', 'test-2');
+        	
+		cy.get('.newfold-notifications-wrapper #notification-test-2')
+			.should('be.visible');
+        cy.get('.newfold-notifications-wrapper #notification-test-2')
+            .contains('display on home and onboarding screens');
+		
+
+		cy.get('#notification-test-2 button.notice-dismiss[data-action="close"]').click();		
+		// cy.wait('@notificationDismiss');
+		cy.wait(2000);
+		cy.get('.newfold-notifications-wrapper #notification-test-2')
+			.should('not.exist');
+		
+	});
+
+	// these can be updated later on, but currently the wp-admin tests are not loaded via the api
+	// so we can't intercept with test notifications
+	it('Container Exists in wp-admin', () => {
+		cy.visit('/wp-admin/index.php');
+		cy.wait(1000);
+        cy.get('.newfold-notifications-wrapper').should('have.length', 1);
+	});
+
+    // click events triggered
+    // plugin search notifications render properly
+
+});


### PR DESCRIPTION
This moves the cypress test specification file and the notification fixture into the module. On the plugin side, we'll remove the notification test files since they can be loaded directly from the module. This will get the test files closer to the code they test.