### PR TITLE
fix typo and test

### DIFF
--- a/includes/AdminNotices.php
+++ b/includes/AdminNotices.php
@@ -65,7 +65,7 @@ class AdminNotices {
 	 * Open the notifactions container
 	 */
 	public static function openContainer() {
-		echo wp_kses_post( '<div id="newfold-notificatons" class="newfold-notifications-wrapper">' );
+		echo wp_kses_post( '<div id="newfold-notifications" class="newfold-notifications-wrapper">' );
 	}
 
 	/**

--- a/tests/cypress/integration/notifications.cy.js
+++ b/tests/cypress/integration/notifications.cy.js
@@ -163,8 +163,7 @@ describe('Notifications', () => {
 	// so we can't intercept with test notifications
 	it('Container Exists in wp-admin', () => {
 		cy.visit('/wp-admin/index.php');
-		cy.wait(1000);
-        cy.get('.newfold-notifications-wrapper').should('have.length', 1);
+        cy.get('#newfold-notifications').should('exist');
 	});
 
     // click events triggered


### PR DESCRIPTION
Found a typo in the notifications container id attribute.

This fixes the typo and uses the id as a selector in the notifications test. Removes the wait which was causing an error.