### PR TITLE
Update/use runtime

### DIFF
--- a/assets/js/components/notification/index.js
+++ b/assets/js/components/notification/index.js
@@ -17,7 +17,7 @@ const Notification = ({ id, content, methods, constants, ...props }) => {
         if ( noticeContainer ) {
             noticeContainer.classList.add('is-dismissed');
             methods.apiFetch( {
-                url: `${constants.resturl}/newfold-notifications/v1/notifications/${id}`,
+                url: `${window.NewfoldRuntime.restUrl}newfold-notifications/v1/notifications/${id}`,
                 method: 'DELETE'
             }).then( ( response ) => {
                 methods.removeNotification(response.id);
@@ -34,7 +34,7 @@ const Notification = ({ id, content, methods, constants, ...props }) => {
         event.data = event.data || {};
         event.data.page = window.location.href;
         methods.apiFetch({
-            path: `${constants.resturl}/newfold-data/v1/events/`,
+            path: `${window.NewfoldRuntime.restUrl}newfold-data/v1/events/`,
             method: 'POST', 
             data: event
         });

--- a/assets/js/components/notifications/index.js
+++ b/assets/js/components/notifications/index.js
@@ -154,6 +154,7 @@ const Notifications = ({methods, constants, ...props}) => {
             {activeNotifications.map(notification => (
                 <Notification 
                     id={notification.id} 
+                    key={notification.id}
                     content={notification.content}
                     constants={constants}
                     methods={methods}

--- a/assets/js/components/notifications/index.js
+++ b/assets/js/components/notifications/index.js
@@ -30,7 +30,10 @@ const Notifications = ({methods, constants, ...props}) => {
     // on mount load all notifications from module api
     methods.useEffect(() => {
         methods.apiFetch( {
-            url: `${constants.resturl}/newfold-notifications/v1/notifications&context=${constants.context}`
+            url: methods.addQueryArgs( 
+                `${window.NewfoldRuntime.restUrl}newfold-notifications/v1/notifications`, 
+                { context: constants.context }
+            )
         }).then( ( response ) => {
             setAllNotifications(response);
 		});

--- a/assets/js/dismiss-notices.js
+++ b/assets/js/dismiss-notices.js
@@ -7,13 +7,13 @@
 			const id = notice.getAttribute('data-id');
 			notice.parentNode.removeChild(notice);
 			window.fetch(
-				`${ window.newfoldNotices.restApiUrl }newfold-notifications/v1/notifications/${ id }`,
+				`${ window.NewfoldRuntime.restUrl }newfold-notifications/v1/notifications/${ id }`,
 				{
 					credentials: 'same-origin',
 					method: 'DELETE',
 					headers: {
 						'Content-Type': 'application/json',
-						'X-WP-Nonce': window.newfoldNotices.restApiNonce,
+						'X-WP-Nonce': window.NewfoldRuntime.restNonce,
 					},
 				}
 			);
@@ -36,13 +36,13 @@
 				data.href = e.target.getAttribute('href');
 			}
 			window.fetch(
-				`${ window.newfoldNotices.restApiUrl }newfold-data/v1/events/`,
+				`${ window.NewfoldRuntime.restUrl }newfold-data/v1/events/`,
 				{
 					credentials: 'same-origin',
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',
-						'X-WP-Nonce': window.newfoldNotices.restApiNonce,
+						'X-WP-Nonce': window.NewfoldRuntime.restNonce,
 					},
 					body: JSON.stringify(data),
 				}

--- a/assets/js/realtime-notices.js
+++ b/assets/js/realtime-notices.js
@@ -106,13 +106,13 @@
 			e.preventDefault();
 			this.removeElement();
 			window.fetch(
-				`${ window.newfoldRealtimeNotices.restApiUrl }newfold-notifications/v1/notifications/${ this.id }`,
+				`${ window.NewfoldRuntime.restUrl }newfold-notifications/v1/notifications/${ this.id }`,
 				{
 					credentials: 'same-origin',
 					method: 'DELETE',
 					headers: {
 						'Content-Type': 'application/json',
-						'X-WP-Nonce': window.newfoldRealtimeNotices.restApiNonce,
+						'X-WP-Nonce': window.NewfoldRuntime.restNonce,
 					},
 				}
 			);
@@ -132,13 +132,13 @@
 				data.href = e.target.getAttribute('href');
 			}
 			window.fetch(
-				`${ window.newfoldRealtimeNotices.restApiUrl }newfold-data/v1/events/`,
+				`${ window.NewfoldRuntime.restUrl }newfold-data/v1/events/`,
 				{
 					credentials: 'same-origin',
 					method: 'POST',
 					headers: {
 						'Content-Type': 'application/json',
-						'X-WP-Nonce': window.newfoldRealtimeNotices.restApiNonce,
+						'X-WP-Nonce': window.NewfoldRuntime.restNonce,
 					},
 					body: JSON.stringify(data),
 				}
@@ -190,13 +190,13 @@
 			event.queue = false;
 			window
 				.fetch(
-					`${ window.newfoldRealtimeNotices.restApiUrl }newfold-notifications/v1/notifications/events`,
+					`${ window.NewfoldRuntime.restUrl }newfold-notifications/v1/notifications/events`,
 					{
 						credentials: 'same-origin',
 						method: 'POST',
 						headers: {
 							'Content-Type': 'application/json',
-							'X-WP-Nonce': window.newfoldRealtimeNotices.restApiNonce,
+							'X-WP-Nonce': window.NewfoldRuntime.restNonce,
 						},
 						body: JSON.stringify(event),
 					}

--- a/includes/AdminNotices.php
+++ b/includes/AdminNotices.php
@@ -87,7 +87,7 @@ class AdminNotices {
 			wp_enqueue_script(
 				'newfold-plugin-realtime-notices',
 				plugins_url( 'vendor/newfold-labs/wp-module-notifications/assets/js/realtime-notices.js', container()->plugin()->file ),
-				array( 'lodash' ),
+				array( 'lodash', 'nfd-runtime' ),
 				container()->plugin()->version,
 				true
 			);
@@ -105,7 +105,7 @@ class AdminNotices {
 		wp_enqueue_script(
 			'newfold-dismiss-notices',
 			plugins_url( 'vendor/newfold-labs/wp-module-notifications/assets/js/dismiss-notices.js', container()->plugin()->file ),
-			array(),
+			array( 'nfd-runtime' ),
 			container()->plugin()->version,
 			true
 		);

--- a/includes/AdminNotices.php
+++ b/includes/AdminNotices.php
@@ -91,14 +91,6 @@ class AdminNotices {
 				container()->plugin()->version,
 				true
 			);
-			wp_localize_script(
-				'newfold-plugin-realtime-notices',
-				'newfoldRealtimeNotices',
-				array(
-					'restApiUrl'   => esc_url_raw( rest_url() ),
-					'restApiNonce' => wp_create_nonce( 'wp_rest' ),
-				)
-			);
 		}
 
 		// Enqueue and set local values for dismiss script
@@ -108,14 +100,6 @@ class AdminNotices {
 			array( 'nfd-runtime' ),
 			container()->plugin()->version,
 			true
-		);
-		wp_localize_script(
-			'newfold-dismiss-notices',
-			'newfoldNotices',
-			array(
-				'restApiUrl'   => esc_url_raw( rest_url() ),
-				'restApiNonce' => wp_create_nonce( 'wp_rest' ),
-			)
 		);
 	}
 

--- a/includes/NotificationsRepository.php
+++ b/includes/NotificationsRepository.php
@@ -60,7 +60,7 @@ class NotificationsRepository {
 			wp_enqueue_script(
 				'newfold-notices-primer',
 				plugins_url( 'vendor/newfold-labs/wp-module-notifications/assets/js/prime-notices.js', container()->plugin()->file ),
-				array( 'wp-dom-ready', 'wp-api-fetch' ),
+				array( 'wp-dom-ready', 'wp-api-fetch', 'nfd-runtime' ),
 				container()->plugin()->version,
 				true
 			);


### PR DESCRIPTION
This updates the module to use the `NewfoldRuntime` object and script that was created recently. It updates using localized values for the rest endpoint and nonce to using the values within the runtime object. It adds the runtime script as a dependency for each script in the module too, so the object should be accessible in all scripts where it is used.

We no longer need to pass the `resturl` into the component as a `constant` as it is available on the runtime object. However, we do need to add the `addQueryArgs` to the component `methods` so we can properly create the request - the `?` in the path sometimes needs to be a `&` depending on permalink settings and the `restUrl` value when sending the context to the endpoint as we do in the `js/components/notifications/index.js` component.