### PR TITLE
fix intercepts in tests for updated resturl

### DIFF
--- a/tests/cypress/integration/notifications.cy.js
+++ b/tests/cypress/integration/notifications.cy.js
@@ -73,7 +73,7 @@ describe('Notifications', () => {
 
 		cy.intercept({
 			method: 'GET',
-			url: '**newfold-notifications**'
+			url:  /newfold-notifications(\/|%2F)v1(\/|%2F)notifications/
 		}, notifications );
 
 		cy.visit('/wp-admin/admin.php?page=' + Cypress.env('pluginId') + '#/home', {timeout: 30000});
@@ -132,7 +132,7 @@ describe('Notifications', () => {
 
 		cy.intercept({
 			method: 'POST',
-			url: '**newfold-notifications**',
+			url: /newfold-notifications(\/|%2F)v1(\/|%2F)notifications/,
 		}, {
             body: {"id":"test-2"}
         } ).as('dismissNotificaiton');


### PR DESCRIPTION
Forgot to update the intercept in cypress test in the last release. Since the URL changed, need to update the match for the intercept. This fixes tests in bluehost, other plugins were excluding this test still so was not noticed there.