### PR TITLE
Update URL for Satis

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A module for managing Newfold in-site notifications.
 ### 1. Add the Newfold Satis to your `composer.json`.
 
  ```bash
- composer config repositories.newfold composer https://newfold.github.io/satis
+ composer config repositories.newfold composer https://newfold-labs.github.io/satis
  ```
 
 ### 2. Require the `newfold-labs/wp-module-notifications` package.


### PR DESCRIPTION
Updates the Satis url from `newfold.github.io` to the correct `newfold-labs.github.io`.