### PR TITLE
Add messages context in the app side nav

### DIFF
--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -31,6 +31,7 @@ jobs:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'bluehost/bluehost-wordpress-plugin'
+      plugin-branch: 'add/app-nav-notifications'
     secrets: inherit
 
   hostgator:

--- a/assets/js/components/notifications/index.js
+++ b/assets/js/components/notifications/index.js
@@ -150,7 +150,7 @@ const Notifications = ({methods, constants, ...props}) => {
         );
     }
 
-    if ('bluehost-app-nav' === constants.context && activeNotifications.length > 0) {
+    if (`${window.NewfoldRuntime.plugin.brand}-app-nav` === constants.context && activeNotifications.length > 0) {
         return (
             <div className={methods.classnames('newfold-nav-notifications-wrapper nfd-mt-4')}>
                 <Notification 

--- a/assets/js/components/notifications/index.js
+++ b/assets/js/components/notifications/index.js
@@ -37,15 +37,15 @@ const Notifications = ({methods, constants, ...props}) => {
             )
         }).then( ( response ) => {
             setAllNotifications(response);
-		});
-	}, [] );
+        });
+    }, [] );
 
     // on update notifications, context or page calculate active notifications
     methods.useEffect(() => {
         setActiveNotifications(
             filterNotifications(allNotifications)
         );
-	}, [allNotifications, constants.page]);
+    }, [allNotifications, constants.page]);
 
     /**
      * Wrapper method to filter notifications
@@ -73,7 +73,7 @@ const Notifications = ({methods, constants, ...props}) => {
      * @returns Array of filtered notifications - removes expired notifications
      */
     const filterByExpiry = (notifications) => {
-        const now = Date.now();
+        const now = Math.round(Date.now() / 1000);
         // console.log( 'Now: ' + now );
         // filter out expired notifications
         return methods.filter(notifications, 
@@ -150,19 +150,33 @@ const Notifications = ({methods, constants, ...props}) => {
         );
     }
 
-    return (
-        <div className={methods.classnames('newfold-notifications-wrapper')}>
-            {activeNotifications.map(notification => (
+    if ('bluehost-app-nav' === constants.context && activeNotifications.length > 0) {
+        return (
+            <div className={methods.classnames('newfold-nav-notifications-wrapper nfd-mt-4')}>
                 <Notification 
-                    id={notification.id} 
-                    key={notification.id}
-                    content={notification.content}
+                    id={activeNotifications[0].id} 
+                    key={activeNotifications[0].id}
+                    content={activeNotifications[0].content}
                     constants={constants}
                     methods={methods}
                 />
-            ))}
-        </div>
-    )
+            </div>
+        );
+    } else {
+        return (
+            <div className={methods.classnames('newfold-notifications-wrapper')}>
+                {activeNotifications.map(notification => (
+                    <Notification 
+                        id={notification.id} 
+                        key={notification.id}
+                        content={notification.content}
+                        constants={constants}
+                        methods={methods}
+                    />
+                ))}
+            </div>
+        );
+    }
 
 };
 

--- a/includes/Notification.php
+++ b/includes/Notification.php
@@ -121,6 +121,7 @@ class Notification {
 					}
 
 				case container()->plugin()->id . '-plugin':
+				case container()->plugin()->id . '-app-nav':
 					// The current page
 					$current_page = Arr::get( $contextData, 'page' );
 

--- a/includes/NotificationsApi.php
+++ b/includes/NotificationsApi.php
@@ -52,6 +52,7 @@ class NotificationsApi {
 						'validate_callback' => function ( $value ) {
 							return is_string( $value ) && in_array( $value, array(
 									container()->plugin()->id . '-plugin',
+									container()->plugin()->id . '-app-nav',
 									'wp-admin-notice',
 									'wp-admin-prime'
 								), true );
@@ -61,7 +62,7 @@ class NotificationsApi {
 						'required'          => false,
 						'validate_callback' => function ( $value, \WP_REST_Request $request ) {
 							$context = $request->get_param( 'context' );
-							if ( container()->plugin()->id . '-plugin' === $context || 'wp-admin-notice' === $context ) {
+							if ( container()->plugin()->id . '-plugin' === $context || container()->plugin()->id . '-app-nav' === $context || 'wp-admin-notice' === $context ) {
 								return is_string( $value );
 							}
 

--- a/tests/cypress/integration/notifications.cy.js
+++ b/tests/cypress/integration/notifications.cy.js
@@ -8,7 +8,7 @@ const notifications = [
 				pages: '#/settings',
 			},
 		],
-		expiration: 2748863456503,
+		expiration: 2748820256,
 		content:
 			'<div class="newfold-notice notice notice-success" style="position:relative;"><p>Notice should only display on plugin app settings page<button type="button" data-action="close" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button></p></div>',
 	},
@@ -20,7 +20,7 @@ const notifications = [
 				pages: [ '#/home/onboarding', '#/home' ],
 			},
 		],
-		expiration: 2749860279240,
+		expiration: 2749860279,
 		content:
 			'<div class="newfold-notice notice notice-error" style="position:relative;"><p>Here is a plugin notice it should display on home and onboarding screens only! <button type="button" data-action="close" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button></p></div>',
 	},
@@ -32,7 +32,7 @@ const notifications = [
 				pages: [ '#/marketplace' ],
 			},
 		],
-		expiration: 2749860279240,
+		expiration: 2749860279,
 		content:
 			'<div class="newfold-notice notice notice-info" style="position:relative;"><p>Here is a plugin notice it should display on marketplace themes screen only! <button type="button" data-action="close" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button></p></div>',
 	},
@@ -48,9 +48,21 @@ const notifications = [
 				pages: 'all',
 			},
 		],
-		expiration: 2749860279240,
+		expiration: 2749860279,
 		content:
 			'<div class="newfold-notice notice notice-warning" style="position:relative;"><p>Here is a notice it should display everywhere in the app and in wp-admin! <button type="button" data-action="close" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button></p></div>',
+	},
+	{
+		id: 'test-5',
+		locations: [
+			{
+				context: Cypress.env( 'pluginId' ) + '-app-nav',
+				pages: 'all',
+			},
+		],
+		expiration: 2749860279,
+		content:
+			'<div class="newfold-notice notice" style="position:relative; display: block;"><p>Notice should display in the app side nav<button type="button" data-action="close" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button></p></div>',
 	},
 	{
 		id: 'test-expired',
@@ -60,7 +72,7 @@ const notifications = [
 				pages: 'all',
 			},
 		],
-		expiration: 1649860279240,
+		expiration: 1649817079,
 		content:
 			'<div class="newfold-notice notice notice-error" style="position:relative;"><p>Here is an expired notice it should never display anywhere even though it has location `all` <button type="button" data-action="close" class="notice-dismiss"><span class="screen-reader-text">Dismiss this notice.</span></button></p></div>',
 	},
@@ -70,7 +82,7 @@ describe( 'Notifications', () => {
 	const appClass = '.' + Cypress.env( 'appId' );
 
 	before( () => {
-		cy.exec( 'npx wp-env run cli wp transient delete newfold_notifications' );
+		cy.exec( 'npx wp-env run cli wp transient delete newfold_notifications', {failOnNonZeroExit: false} );
 		cy.visit( '/wp-admin/index.php' );
 		cy.intercept(
 			{
@@ -129,6 +141,18 @@ describe( 'Notifications', () => {
 		cy.get(
 			'.newfold-notifications-wrapper #notification-test-1'
 		).contains( 'display on plugin app settings page' );
+	} );
+
+	// notification renders on the side nav
+	it( 'Test notification displays in app side nav', () => {
+		cy.get( '.newfold-nav-notifications-wrapper #notification-test-5' )
+			.should( 'be.visible' )
+			.should( 'have.attr', 'data-id' )
+			.and( 'equal', 'test-5' );
+
+		cy.get(
+			'.newfold-nav-notifications-wrapper #notification-test-5'
+		).contains( 'display in the app side nav' );
 	} );
 
 	// expired notification should not show


### PR DESCRIPTION
## Proposed changes
Add a new `container()->plugin()->id . '-app-nav'` context to the module API, this context can be used by the brand plugins to retrieve notifications that can be displayed in the app nav.

** Tests might be failing now as this change requires an update in the brand plugin's app to render the messages in this context in the side nav.

This PR addresses this internal ticket: https://jira.newfold.com/browse/PRESS0-1151

#### Demo
https://github.com/newfold-labs/wp-module-notifications/assets/38976631/1ccb6109-d44c-4b3a-b63d-179fc6ad2d3e

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
