### PR TITLE
Display Premium plugins (Laravel Hiive messages) at the beginning of WordPress plugin search results.

### DIFF
--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -31,6 +31,7 @@ jobs:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'bluehost/bluehost-wordpress-plugin'
+      plugin-branch: 'main'
     secrets: inherit
 
   hostgator:

--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -31,7 +31,6 @@ jobs:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'bluehost/bluehost-wordpress-plugin'
-      plugin-branch: 'add/app-nav-notifications'
     secrets: inherit
 
   hostgator:

--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -31,7 +31,7 @@ jobs:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'bluehost/bluehost-wordpress-plugin'
-      plugin-branch: 'main'
+      plugin-branch: 'add/app-nav-notifications'
     secrets: inherit
 
   hostgator:

--- a/assets/js/components/notifications/index.js
+++ b/assets/js/components/notifications/index.js
@@ -102,6 +102,10 @@ const Notifications = ({methods, constants, ...props}) => {
                 // );
                 var isContextMatch = false;
                 notification.locations.forEach(location => {
+                    if ( location.context === 'wp-plugin-search' ) {
+                        isContextMatch = false;
+                        return;
+                    }
                     if ( location.context === constants.context ) {
                         isContextMatch = true;
                     }
@@ -163,16 +167,18 @@ const Notifications = ({methods, constants, ...props}) => {
             </div>
         );
     } else {
+        console.log(activeNotifications);
         return (
             <div className={methods.classnames('newfold-notifications-wrapper')}>
                 {activeNotifications.map(notification => (
-                    <Notification 
+                                            <Notification 
                         id={notification.id} 
                         key={notification.id}
                         content={notification.content}
                         constants={constants}
                         methods={methods}
                     />
+
                 ))}
             </div>
         );

--- a/assets/js/components/notifications/index.js
+++ b/assets/js/components/notifications/index.js
@@ -102,7 +102,7 @@ const Notifications = ({methods, constants, ...props}) => {
                 // );
                 var isContextMatch = false;
                 notification.locations.forEach(location => {
-                    if ( location.context === 'wp-plugin-search' ) {
+                    if ( location.context === 'wp-plugin-search' || location.context === 'wp-theme-search' ) {
                         isContextMatch = false;
                         return;
                     }

--- a/assets/js/components/notifications/index.js
+++ b/assets/js/components/notifications/index.js
@@ -167,11 +167,10 @@ const Notifications = ({methods, constants, ...props}) => {
             </div>
         );
     } else {
-        console.log(activeNotifications);
         return (
             <div className={methods.classnames('newfold-notifications-wrapper')}>
                 {activeNotifications.map(notification => (
-                                            <Notification 
+                    <Notification 
                         id={notification.id} 
                         key={notification.id}
                         content={notification.content}

--- a/assets/js/components/notifications/index.js
+++ b/assets/js/components/notifications/index.js
@@ -177,7 +177,6 @@ const Notifications = ({methods, constants, ...props}) => {
                         constants={constants}
                         methods={methods}
                     />
-
                 ))}
             </div>
         );

--- a/assets/js/realtime-notices.js
+++ b/assets/js/realtime-notices.js
@@ -168,10 +168,9 @@
 			}
 
 			const queryTokens = this.searchQuery.split(" ");
-			
+			const regexPattern = new RegExp('^' + this.storedQuery.toLowerCase().replace(/\*/g, '.*') + '$');
 			let isQueryMatch = false;
 			queryTokens.forEach(queryToken => {
-				const regexPattern = new RegExp('^' + this.storedQuery.toLowerCase().replace(/\*/g, '.*') + '$');
 				if (regexPattern.test(queryToken.toLowerCase())) {
 					isQueryMatch = true;
 					return;

--- a/assets/js/realtime-notices.js
+++ b/assets/js/realtime-notices.js
@@ -171,7 +171,8 @@
 			
 			let isQueryMatch = false;
 			queryTokens.forEach(queryToken => {
-				if (this.storedQuery.toLowerCase().includes(queryToken.toLowerCase())) {
+				const regexPattern = new RegExp('^' + this.storedQuery.toLowerCase().replace(/\*/g, '.*') + '$');
+				if (regexPattern.test(queryToken.toLowerCase())) {
 					isQueryMatch = true;
 					return;
 				}

--- a/includes/AdminNotices.php
+++ b/includes/AdminNotices.php
@@ -87,7 +87,7 @@ class AdminNotices {
 
 		// Handle realtime notifications
 		$screen = get_current_screen();
-		if ( 'plugin-install' === $screen->id ) {
+		if ( 'plugin-install' === $screen->id || 'theme-install' === $screen->id ) {
 			// Enqueue and set local values for realtime script on plugin install page only
 			wp_enqueue_script(
 				'newfold-plugin-realtime-notices',
@@ -96,6 +96,11 @@ class AdminNotices {
 				container()->plugin()->version,
 				true
 			);
+
+			// Localize the script with screen ID
+			wp_localize_script( 'newfold-plugin-realtime-notices', 'newfoldRealtimeData', array(
+				'screenID' => $screen->id,
+			) );
 		}
 
 		// Enqueue and set local values for dismiss script


### PR DESCRIPTION
## Proposed changes

This PR enhances the wp-module-notification module to display Laravel Hiive messages at the beginning of WordPress plugin search results.

- Added a new component to display Laravel Hiive messages.
- Utilized a new context, wp-plugin-search, to distinguish these messages from existing admin banner notifications.
- Users can now receive relevant Laravel Hiive messages directly in the WordPress plugin search results container when conducting plugin searches.
- This update aims to prominently display our premium plugins at the beginning of the search results, ensuring better visibility.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
