### PR TITLE
assert less specific onboarding url

### DIFF
--- a/tests/cypress/integration/notifications.cy.js
+++ b/tests/cypress/integration/notifications.cy.js
@@ -169,7 +169,7 @@ describe( 'Notifications', () => {
 				.click();
 			cy.url().should(
 				'include',
-				'/index.php?page=nfd-onboarding#/wp-setup/step/fork'
+				'nfd-onboarding#/wp-setup/step'
 			);
 			cy.get( '.nfd-onboarding-sitegen-options__option--large' ).should(
 				'be.visible'


### PR DESCRIPTION
The ai test asserts the onboarding url, but this URL depends on some capabilities, so we can be less specific in the URL assertion.

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
