### PR TITLE
feat(i18n): Composer i18n scripts, catalogs, and auto-translate

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -1,0 +1,27 @@
+name: Check for Updates to Translations
+
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the branch that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  translate:
+    name: 'Check and update translations'
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    with:
+      text_domain: 'wp-module-notifications'
+    secrets:
+      TRANSLATOR_API_KEY: ${{ secrets.TRANSLATOR_API_KEY }}

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "newfold-labs/wp-php-standards": "^1.2",
         "johnpbloch/wordpress": "@stable",
         "lucatume/wp-browser": "*",
-        "phpunit/phpcov": "*"
+        "phpunit/phpcov": "*",
+        "wp-cli/i18n-command": "^2.7.0"
     },
     "require": {
         "newfold-labs/wp-module-data": "^2.9.3",
@@ -53,6 +54,24 @@
     },
     "scripts": {
         "fix": "vendor/bin/phpcbf --standard=phpcs.xml .",
+        "i18n": [
+            "@i18n-pot",
+            "@i18n-po",
+            "@i18n-php",
+            "@i18n-json"
+        ],
+        "i18n-ci-pre": [
+            "@i18n-pot",
+            "@i18n-po"
+        ],
+        "i18n-ci-post": [
+            "@i18n-json",
+            "@i18n-php"
+        ],
+        "i18n-json": "rm -f languages/*.json && vendor/bin/wp i18n make-json ./languages --pretty-print",
+        "i18n-php": "vendor/bin/wp i18n make-php ./languages --pretty-print",
+        "i18n-po": "vendor/bin/wp i18n update-po ./languages/wp-module-notifications.pot ./languages",
+        "i18n-pot": "vendor/bin/wp i18n make-pot . ./languages/wp-module-notifications.pot --domain=wp-module-notifications --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/wp-module-notifications/issues\",\"POT-Creation-Date\":\"2025-02-13T09:55:55+00:00\"}' --exclude=tests,vendor,wordpress,node_modules",
         "lint": "vendor/bin/phpcs --standard=phpcs.xml -s .",
         "test": [
             "codecept run wpunit"
@@ -74,6 +93,13 @@
         }
     },
     "scripts-descriptions": {
+        "i18n": "Run the full local i18n pipeline (POT, PO, PHP, JSON).",
+        "i18n-ci-pre": "CI: regenerate the POT file and sync PO catalogs from it.",
+        "i18n-ci-post": "CI: regenerate JED JSON and PHP translation files from PO catalogs.",
+        "i18n-json": "Remove stale JSON catalogs, then generate JED JSON from PO files using wp i18n make-json.",
+        "i18n-php": "Generate PHP translation files from PO files using wp i18n make-php.",
+        "i18n-po": "Update PO files from the POT file using wp i18n update-po.",
+        "i18n-pot": "Scan source and generate the POT translation template using wp i18n make-pot.",
         "test": "Run tests.",
         "test-coverage": "Run tests with coverage, merge coverage and create HTML report."
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11e3d2dfbdde0c2fdbea3c17b05b2fe9",
+    "content-hash": "18bbefbe9ea3c9b19d1e034ad0f10e8d",
     "packages": [
         {
             "name": "doctrine/inflector",
@@ -1505,6 +1505,220 @@
             "time": "2022-12-30T00:15:36+00:00"
         },
         {
+            "name": "eftec/bladeone",
+            "version": "3.52",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/EFTEC/BladeOne.git",
+                "reference": "a19bf66917de0b29836983db87a455a4f6e32148"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/EFTEC/BladeOne/zipball/a19bf66917de0b29836983db87a455a4f6e32148",
+                "reference": "a19bf66917de0b29836983db87a455a4f6e32148",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16.1",
+                "phpunit/phpunit": "^5.7",
+                "squizlabs/php_codesniffer": "^3.5.4"
+            },
+            "suggest": {
+                "eftec/bladeonehtml": "Extension to create forms",
+                "ext-mbstring": "This extension is used if it's active"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "eftec\\bladeone\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jorge Patricio Castro Castillo",
+                    "email": "jcastro@eftec.cl"
+                }
+            ],
+            "description": "The standalone version Blade Template Engine from Laravel in a single php file",
+            "homepage": "https://github.com/EFTEC/BladeOne",
+            "keywords": [
+                "blade",
+                "php",
+                "template",
+                "templating",
+                "view"
+            ],
+            "support": {
+                "issues": "https://github.com/EFTEC/BladeOne/issues",
+                "source": "https://github.com/EFTEC/BladeOne/tree/3.52"
+            },
+            "time": "2021-04-17T13:49:01+00:00"
+        },
+        {
+            "name": "gettext/gettext",
+            "version": "v4.8.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-gettext/Gettext.git",
+                "reference": "11af89ee6c087db3cf09ce2111a150bca5c46e12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/11af89ee6c087db3cf09ce2111a150bca5c46e12",
+                "reference": "11af89ee6c087db3cf09ce2111a150bca5c46e12",
+                "shasum": ""
+            },
+            "require": {
+                "gettext/languages": "^2.3",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "illuminate/view": "^5.0.x-dev",
+                "phpunit/phpunit": "^4.8|^5.7|^6.5",
+                "squizlabs/php_codesniffer": "^3.0",
+                "symfony/yaml": "~2",
+                "twig/extensions": "*",
+                "twig/twig": "^1.31|^2.0"
+            },
+            "suggest": {
+                "illuminate/view": "Is necessary if you want to use the Blade extractor",
+                "symfony/yaml": "Is necessary if you want to use the Yaml extractor/generator",
+                "twig/extensions": "Is necessary if you want to use the Twig extractor",
+                "twig/twig": "Is necessary if you want to use the Twig extractor"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Gettext\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oscar Otero",
+                    "email": "oom@oscarotero.com",
+                    "homepage": "http://oscarotero.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP gettext manager",
+            "homepage": "https://github.com/oscarotero/Gettext",
+            "keywords": [
+                "JS",
+                "gettext",
+                "i18n",
+                "mo",
+                "po",
+                "translation"
+            ],
+            "support": {
+                "email": "oom@oscarotero.com",
+                "issues": "https://github.com/oscarotero/Gettext/issues",
+                "source": "https://github.com/php-gettext/Gettext/tree/v4.8.12"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/oscarotero",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/oscarotero",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/misteroom",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2024-05-18T10:25:07+00:00"
+        },
+        {
+            "name": "gettext/languages",
+            "version": "2.12.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-gettext/Languages.git",
+                "reference": "079d6f4842cbcbf5673a70d8e93169a684e7aadd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/079d6f4842cbcbf5673a70d8e93169a684e7aadd",
+                "reference": "079d6f4842cbcbf5673a70d8e93169a684e7aadd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.4"
+            },
+            "bin": [
+                "bin/export-plural-rules",
+                "bin/import-cldr-data"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Gettext\\Languages\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michele Locati",
+                    "email": "mlocati@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "gettext languages with plural rules",
+            "homepage": "https://github.com/php-gettext/Languages",
+            "keywords": [
+                "cldr",
+                "i18n",
+                "internationalization",
+                "l10n",
+                "language",
+                "languages",
+                "localization",
+                "php",
+                "plural",
+                "plural rules",
+                "plurals",
+                "translate",
+                "translations",
+                "unicode"
+            ],
+            "support": {
+                "issues": "https://github.com/php-gettext/Languages/issues",
+                "source": "https://github.com/php-gettext/Languages/tree/2.12.2"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/mlocati",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/mlocati",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-23T14:05:50+00:00"
+        },
+        {
             "name": "guzzlehttp/guzzle",
             "version": "7.9.3",
             "source": {
@@ -2132,6 +2346,55 @@
                 }
             ],
             "time": "2025-02-22T12:33:32+00:00"
+        },
+        {
+            "name": "mck89/peast",
+            "version": "v1.17.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mck89/peast.git",
+                "reference": "e19a8bd896b7f04941a38fd38a140c9a6531c84f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/e19a8bd896b7f04941a38fd38a140c9a6531c84f",
+                "reference": "e19a8bd896b7f04941a38fd38a140c9a6531c84f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.17.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Peast\\": "lib/Peast/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Marchiò",
+                    "email": "marco.mm89@gmail.com"
+                }
+            ],
+            "description": "Peast is PHP library that generates AST for JavaScript code",
+            "support": {
+                "issues": "https://github.com/mck89/peast/issues",
+                "source": "https://github.com/mck89/peast/tree/v1.17.5"
+            },
+            "time": "2026-03-15T10:47:07+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -6415,6 +6678,311 @@
             "time": "2022-10-16T00:51:09+00:00"
         },
         {
+            "name": "wp-cli/i18n-command",
+            "version": "v2.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/i18n-command.git",
+                "reference": "e91e6903d212486e32ed2c916171f661bfc539ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/e91e6903d212486e32ed2c916171f661bfc539ce",
+                "reference": "e91e6903d212486e32ed2c916171f661bfc539ce",
+                "shasum": ""
+            },
+            "require": {
+                "eftec/bladeone": "3.52",
+                "gettext/gettext": "^4.8",
+                "mck89/peast": "^1.13.11",
+                "wp-cli/wp-cli": "^2.12"
+            },
+            "require-dev": {
+                "wp-cli/scaffold-command": "^1.2 || ^2",
+                "wp-cli/wp-cli-tests": "^5.0.0"
+            },
+            "suggest": {
+                "ext-json": "Used for reading and generating JSON translation files",
+                "ext-mbstring": "Used for calculating include/exclude matches in code extraction"
+            },
+            "type": "wp-cli-package",
+            "extra": {
+                "bundled": true,
+                "commands": [
+                    "i18n",
+                    "i18n audit",
+                    "i18n make-pot",
+                    "i18n make-json",
+                    "i18n make-mo",
+                    "i18n make-php",
+                    "i18n update-po"
+                ],
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "i18n-command.php"
+                ],
+                "psr-4": {
+                    "WP_CLI\\I18n\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pascal Birchler",
+                    "homepage": "https://pascalbirchler.com/"
+                }
+            ],
+            "description": "Provides internationalization tools for WordPress projects.",
+            "homepage": "https://github.com/wp-cli/i18n-command",
+            "support": {
+                "issues": "https://github.com/wp-cli/i18n-command/issues",
+                "source": "https://github.com/wp-cli/i18n-command/tree/v2.7.0"
+            },
+            "time": "2026-03-16T17:13:39+00:00"
+        },
+        {
+            "name": "wp-cli/mustache",
+            "version": "v2.14.99",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/mustache.php.git",
+                "reference": "ca23b97ac35fbe01c160549eb634396183d04a59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/mustache.php/zipball/ca23b97ac35fbe01c160549eb634396183d04a59",
+                "reference": "ca23b97ac35fbe01c160549eb634396183d04a59",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "replace": {
+                "mustache/mustache": "^2.14.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.19.3",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Mustache": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Justin Hileman",
+                    "email": "justin@justinhileman.info",
+                    "homepage": "http://justinhileman.com"
+                }
+            ],
+            "description": "A Mustache implementation in PHP.",
+            "homepage": "https://github.com/bobthecow/mustache.php",
+            "keywords": [
+                "mustache",
+                "templating"
+            ],
+            "support": {
+                "source": "https://github.com/wp-cli/mustache.php/tree/v2.14.99"
+            },
+            "time": "2025-05-06T16:15:37+00:00"
+        },
+        {
+            "name": "wp-cli/mustangostang-spyc",
+            "version": "0.6.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/spyc.git",
+                "reference": "30f25baaaba939caaff1f4b8c7ed998632f59fe2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/spyc/zipball/30f25baaaba939caaff1f4b8c7ed998632f59fe2",
+                "reference": "30f25baaaba939caaff1f4b8c7ed998632f59fe2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.3.*@dev"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.5.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "includes/functions.php"
+                ],
+                "psr-4": {
+                    "Mustangostang\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "mustangostang",
+                    "email": "vlad.andersen@gmail.com"
+                }
+            ],
+            "description": "A simple YAML loader/dumper class for PHP (WP-CLI fork)",
+            "homepage": "https://github.com/mustangostang/spyc/",
+            "support": {
+                "source": "https://github.com/wp-cli/spyc/tree/0.6.6"
+            },
+            "time": "2026-03-12T12:30:41+00:00"
+        },
+        {
+            "name": "wp-cli/php-cli-tools",
+            "version": "v0.12.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/php-cli-tools.git",
+                "reference": "c3d25138ce46a66647ec0dc9b17bf300338494aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/c3d25138ce46a66647ec0dc9b17bf300338494aa",
+                "reference": "c3d25138ce46a66647ec0dc9b17bf300338494aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7.2.24"
+            },
+            "require-dev": {
+                "roave/security-advisories": "dev-latest",
+                "wp-cli/wp-cli-tests": "^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "0.12.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "lib/cli/cli.php"
+                ],
+                "psr-0": {
+                    "cli": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Bachhuber",
+                    "email": "daniel@handbuilt.co",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "James Logsdon",
+                    "email": "jlogsdon@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Console utilities for PHP",
+            "homepage": "http://github.com/wp-cli/php-cli-tools",
+            "keywords": [
+                "cli",
+                "console"
+            ],
+            "support": {
+                "issues": "https://github.com/wp-cli/php-cli-tools/issues",
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.12.9"
+            },
+            "time": "2026-03-29T11:12:54+00:00"
+        },
+        {
+            "name": "wp-cli/wp-cli",
+            "version": "v2.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/wp-cli.git",
+                "reference": "03d30d4138d12b4bffd8b507b82e56e129e0523f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/03d30d4138d12b4bffd8b507b82e56e129e0523f",
+                "reference": "03d30d4138d12b4bffd8b507b82e56e129e0523f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": "^5.6 || ^7.0 || ^8.0",
+                "symfony/finder": ">2.7",
+                "wp-cli/mustache": "^2.14.99",
+                "wp-cli/mustangostang-spyc": "^0.6.3",
+                "wp-cli/php-cli-tools": "~0.12.4"
+            },
+            "require-dev": {
+                "wp-cli/db-command": "^1.3 || ^2",
+                "wp-cli/entity-command": "^1.2 || ^2",
+                "wp-cli/extension-command": "^1.1 || ^2",
+                "wp-cli/package-command": "^1 || ^2",
+                "wp-cli/wp-cli-tests": "^4.3.10"
+            },
+            "suggest": {
+                "ext-readline": "Include for a better --prompt implementation",
+                "ext-zip": "Needed to support extraction of ZIP archives when doing downloads or updates"
+            },
+            "bin": [
+                "bin/wp",
+                "bin/wp.bat"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "WP_CLI\\": "php/"
+                },
+                "classmap": [
+                    "php/class-wp-cli.php",
+                    "php/class-wp-cli-command.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WP-CLI framework",
+            "homepage": "https://wp-cli.org",
+            "keywords": [
+                "cli",
+                "wordpress"
+            ],
+            "support": {
+                "docs": "https://make.wordpress.org/cli/handbook/",
+                "issues": "https://github.com/wp-cli/wp-cli/issues",
+                "source": "https://github.com/wp-cli/wp-cli"
+            },
+            "time": "2025-05-07T01:16:12+00:00"
+        },
+        {
             "name": "wp-coding-standards/wpcs",
             "version": "3.3.0",
             "source": {
@@ -6483,7 +7051,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "johnpbloch/wordpress": 0
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {},

--- a/languages/wp-module-notifications-de_DE.l10n.php
+++ b/languages/wp-module-notifications-de_DE.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-notifications',
+	'plural-forms' => 'nplurals=2; plural=(n != 1);',
+	'language' => 'de',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:32+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+,
+	],
+];

--- a/languages/wp-module-notifications-de_DE.po
+++ b/languages/wp-module-notifications-de_DE.po
@@ -1,0 +1,35 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-notifications/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:32+00:00\n"
+"Language: de\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-notifications\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bootstrap.php:14
+msgid "Notifications"
+msgstr ""
+
+#: includes/NotificationsApi.php:88
+msgid "Event action"
+msgstr ""
+
+#: includes/NotificationsApi.php:96
+msgid "Event category"
+msgstr ""
+
+#: includes/NotificationsApi.php:103
+msgid "Event data"
+msgstr ""
+
+#: includes/NotificationsApi.php:108
+msgid "Whether or not to queue the event"
+msgstr ""

--- a/languages/wp-module-notifications-en_AU.l10n.php
+++ b/languages/wp-module-notifications-en_AU.l10n.php
@@ -1,0 +1,17 @@
+<?php
+return [
+	'domain' => 'wp-module-notifications',
+	'plural-forms' => 'nplurals=2; plural=(n != 1);',
+	'language' => 'en_AU',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:32+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+		'Notifications' => 'Notifications',
+		'Event action' => 'Event action',
+		'Event category' => 'Event category',
+		'Event data' => 'Event data',
+		'Whether or not to queue the event' => 'Whether or not to queue the event',
+	],
+];

--- a/languages/wp-module-notifications-en_AU.po
+++ b/languages/wp-module-notifications-en_AU.po
@@ -1,0 +1,35 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-notifications/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:32+00:00\n"
+"Language: en_AU\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-notifications\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bootstrap.php:14
+msgid "Notifications"
+msgstr "Notifications"
+
+#: includes/NotificationsApi.php:88
+msgid "Event action"
+msgstr "Event action"
+
+#: includes/NotificationsApi.php:96
+msgid "Event category"
+msgstr "Event category"
+
+#: includes/NotificationsApi.php:103
+msgid "Event data"
+msgstr "Event data"
+
+#: includes/NotificationsApi.php:108
+msgid "Whether or not to queue the event"
+msgstr "Whether or not to queue the event"

--- a/languages/wp-module-notifications-en_GB.l10n.php
+++ b/languages/wp-module-notifications-en_GB.l10n.php
@@ -1,0 +1,17 @@
+<?php
+return [
+	'domain' => 'wp-module-notifications',
+	'plural-forms' => 'nplurals=2; plural=(n != 1);',
+	'language' => 'en_GB',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:32+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+		'Notifications' => 'Notifications',
+		'Event action' => 'Event action',
+		'Event category' => 'Event category',
+		'Event data' => 'Event data',
+		'Whether or not to queue the event' => 'Whether or not to queue the event',
+	],
+];

--- a/languages/wp-module-notifications-en_GB.po
+++ b/languages/wp-module-notifications-en_GB.po
@@ -1,0 +1,35 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-notifications/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:32+00:00\n"
+"Language: en_GB\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-notifications\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bootstrap.php:14
+msgid "Notifications"
+msgstr "Notifications"
+
+#: includes/NotificationsApi.php:88
+msgid "Event action"
+msgstr "Event action"
+
+#: includes/NotificationsApi.php:96
+msgid "Event category"
+msgstr "Event category"
+
+#: includes/NotificationsApi.php:103
+msgid "Event data"
+msgstr "Event data"
+
+#: includes/NotificationsApi.php:108
+msgid "Whether or not to queue the event"
+msgstr "Whether or not to queue the event"

--- a/languages/wp-module-notifications-es_ES.l10n.php
+++ b/languages/wp-module-notifications-es_ES.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-notifications',
+	'plural-forms' => 'nplurals=2; plural=(n != 1);',
+	'language' => 'es',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:32+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+,
+	],
+];

--- a/languages/wp-module-notifications-es_ES.po
+++ b/languages/wp-module-notifications-es_ES.po
@@ -1,0 +1,35 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-notifications/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:32+00:00\n"
+"Language: es\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-notifications\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bootstrap.php:14
+msgid "Notifications"
+msgstr ""
+
+#: includes/NotificationsApi.php:88
+msgid "Event action"
+msgstr ""
+
+#: includes/NotificationsApi.php:96
+msgid "Event category"
+msgstr ""
+
+#: includes/NotificationsApi.php:103
+msgid "Event data"
+msgstr ""
+
+#: includes/NotificationsApi.php:108
+msgid "Whether or not to queue the event"
+msgstr ""

--- a/languages/wp-module-notifications-es_MX.l10n.php
+++ b/languages/wp-module-notifications-es_MX.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-notifications',
+	'plural-forms' => 'nplurals=2; plural=(n != 1);',
+	'language' => 'es_MX',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:32+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+,
+	],
+];

--- a/languages/wp-module-notifications-es_MX.po
+++ b/languages/wp-module-notifications-es_MX.po
@@ -1,0 +1,35 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-notifications/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:32+00:00\n"
+"Language: es_MX\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-notifications\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bootstrap.php:14
+msgid "Notifications"
+msgstr ""
+
+#: includes/NotificationsApi.php:88
+msgid "Event action"
+msgstr ""
+
+#: includes/NotificationsApi.php:96
+msgid "Event category"
+msgstr ""
+
+#: includes/NotificationsApi.php:103
+msgid "Event data"
+msgstr ""
+
+#: includes/NotificationsApi.php:108
+msgid "Whether or not to queue the event"
+msgstr ""

--- a/languages/wp-module-notifications-fr_FR.l10n.php
+++ b/languages/wp-module-notifications-fr_FR.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-notifications',
+	'plural-forms' => 'nplurals=2; plural=(n > 1);',
+	'language' => 'fr',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:32+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+,
+	],
+];

--- a/languages/wp-module-notifications-fr_FR.po
+++ b/languages/wp-module-notifications-fr_FR.po
@@ -1,0 +1,35 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-notifications/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:32+00:00\n"
+"Language: fr\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-notifications\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: bootstrap.php:14
+msgid "Notifications"
+msgstr ""
+
+#: includes/NotificationsApi.php:88
+msgid "Event action"
+msgstr ""
+
+#: includes/NotificationsApi.php:96
+msgid "Event category"
+msgstr ""
+
+#: includes/NotificationsApi.php:103
+msgid "Event data"
+msgstr ""
+
+#: includes/NotificationsApi.php:108
+msgid "Whether or not to queue the event"
+msgstr ""

--- a/languages/wp-module-notifications-it_IT.l10n.php
+++ b/languages/wp-module-notifications-it_IT.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-notifications',
+	'plural-forms' => 'nplurals=2; plural=(n != 1);',
+	'language' => 'it',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:32+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+,
+	],
+];

--- a/languages/wp-module-notifications-it_IT.po
+++ b/languages/wp-module-notifications-it_IT.po
@@ -1,0 +1,35 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-notifications/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:32+00:00\n"
+"Language: it\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-notifications\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bootstrap.php:14
+msgid "Notifications"
+msgstr ""
+
+#: includes/NotificationsApi.php:88
+msgid "Event action"
+msgstr ""
+
+#: includes/NotificationsApi.php:96
+msgid "Event category"
+msgstr ""
+
+#: includes/NotificationsApi.php:103
+msgid "Event data"
+msgstr ""
+
+#: includes/NotificationsApi.php:108
+msgid "Whether or not to queue the event"
+msgstr ""

--- a/languages/wp-module-notifications-nl_NL.l10n.php
+++ b/languages/wp-module-notifications-nl_NL.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-notifications',
+	'plural-forms' => 'nplurals=2; plural=(n != 1);',
+	'language' => 'nl',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:32+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+,
+	],
+];

--- a/languages/wp-module-notifications-nl_NL.po
+++ b/languages/wp-module-notifications-nl_NL.po
@@ -1,0 +1,35 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-notifications/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:32+00:00\n"
+"Language: nl\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-notifications\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: bootstrap.php:14
+msgid "Notifications"
+msgstr ""
+
+#: includes/NotificationsApi.php:88
+msgid "Event action"
+msgstr ""
+
+#: includes/NotificationsApi.php:96
+msgid "Event category"
+msgstr ""
+
+#: includes/NotificationsApi.php:103
+msgid "Event data"
+msgstr ""
+
+#: includes/NotificationsApi.php:108
+msgid "Whether or not to queue the event"
+msgstr ""

--- a/languages/wp-module-notifications-pt_BR.l10n.php
+++ b/languages/wp-module-notifications-pt_BR.l10n.php
@@ -1,0 +1,13 @@
+<?php
+return [
+	'domain' => 'wp-module-notifications',
+	'plural-forms' => 'nplurals=2; plural=(n > 1);',
+	'language' => 'pt_BR',
+	'project-id-version' => '',
+	'pot-creation-date' => '2025-02-13T09:55:55+00:00',
+	'po-revision-date' => '2026-04-03T19:13:32+00:00',
+	'x-generator' => 'WP-CLI 2.12.0',
+	'messages' => [
+,
+	],
+];

--- a/languages/wp-module-notifications-pt_BR.po
+++ b/languages/wp-module-notifications-pt_BR.po
@@ -1,0 +1,35 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-notifications/issues\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: 2026-04-03T19:13:32+00:00\n"
+"Language: pt_BR\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-notifications\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: bootstrap.php:14
+msgid "Notifications"
+msgstr ""
+
+#: includes/NotificationsApi.php:88
+msgid "Event action"
+msgstr ""
+
+#: includes/NotificationsApi.php:96
+msgid "Event category"
+msgstr ""
+
+#: includes/NotificationsApi.php:103
+msgid "Event data"
+msgstr ""
+
+#: includes/NotificationsApi.php:108
+msgid "Whether or not to queue the event"
+msgstr ""

--- a/languages/wp-module-notifications.pot
+++ b/languages/wp-module-notifications.pot
@@ -1,0 +1,33 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: https://github.com/newfold-labs/wp-module-notifications/issues\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2025-02-13T09:55:55+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: wp-module-notifications\n"
+
+#: bootstrap.php:14
+msgid "Notifications"
+msgstr ""
+
+#: includes/NotificationsApi.php:88
+msgid "Event action"
+msgstr ""
+
+#: includes/NotificationsApi.php:96
+msgid "Event category"
+msgstr ""
+
+#: includes/NotificationsApi.php:103
+msgid "Event data"
+msgstr ""
+
+#: includes/NotificationsApi.php:108
+msgid "Whether or not to queue the event"
+msgstr ""


### PR DESCRIPTION
Adds Composer i18n scripts (i18n-pot/po/php/json, i18n-ci-pre/post), wp-cli/i18n-command in require-dev, languages/ (POT, PO, l10n.php, JSON where applicable), and auto-translate workflow where missing. Aligns text domains with wp-module-* where noted in the i18n rollout plan.

P0/P1 implementation per org standard (coming-soon pattern).

Made with [Cursor](https://cursor.com)