### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -19,11 +19,10 @@ permissions: {}
 jobs:
   translate:
     name: 'Check and update translations'
+    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     permissions:
       contents: write       # Required for the reusable workflow to commit translation updates and push branches.
       pull-requests: write  # Required for the reusable workflow to open or update translation pull requests.
-    timeout-minutes: 30
-    uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     with:
       text_domain: 'wp-module-notifications'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,14 +12,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write       # Required for the reusable workflow to commit translation updates and push branches.
+      pull-requests: write  # Required for the reusable workflow to open or update translation pull requests.
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     with:
       text_domain: 'wp-module-notifications'

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: write       # Required for the reusable workflow to commit translation updates and push branches.
       pull-requests: write  # Required for the reusable workflow to open or update translation pull requests.
+    timeout-minutes: 30
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
     with:
       text_domain: 'wp-module-notifications'

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,17 +6,19 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    permissions: {} # No workflow steps call the GitHub REST API with github.token.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -29,6 +31,8 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
+    permissions:
+      contents: read # Required so the reusable workflow can clone private repos with github.token via actions/checkout.
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
@@ -39,6 +43,8 @@ jobs:
   bluehost-dev:
     name: Bluehost DEV Build and Test Playwright
     needs: setup
+    permissions:
+      contents: read # Required so the reusable workflow can clone private repos with github.token via actions/checkout.
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # No workflow steps call the GitHub REST API with github.token.
+    timeout-minutes: 5
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -33,6 +34,7 @@ jobs:
     needs: setup
     permissions:
       contents: read # Required so the reusable workflow can clone private repos with github.token via actions/checkout.
+    timeout-minutes: 60
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
@@ -45,6 +47,7 @@ jobs:
     needs: setup
     permissions:
       contents: read # Required so the reusable workflow can clone private repos with github.token via actions/checkout.
+    timeout-minutes: 60
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,7 +19,6 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # No workflow steps call the GitHub REST API with github.token.
-    timeout-minutes: 5
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -32,10 +31,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required so the reusable workflow can clone private repos with github.token via actions/checkout.
-    timeout-minutes: 60
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -45,10 +43,9 @@ jobs:
   bluehost-dev:
     name: Bluehost DEV Build and Test Playwright
     needs: setup
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required so the reusable workflow can clone private repos with github.token via actions/checkout.
-    timeout-minutes: 60
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # No workflow steps call the GitHub REST API with github.token.
+    timeout-minutes: 5
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,7 +21,6 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # Uses only github.repository in a shell echo; no checkout or github.token REST calls.
-    timeout-minutes: 5
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -31,11 +30,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
+    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     permissions:
       contents: write       # Required for reusable codecoverage to push coverage HTML to gh-pages.
       pull-requests: write  # Required for reusable codecoverage PR comments using secrets.repo_token.
-    timeout-minutes: 90
-    uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # Uses only github.repository in a shell echo; no checkout or github.token REST calls.
+    timeout-minutes: 5
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {} # Uses only github.repository in a shell echo; no checkout or github.token REST calls.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -29,8 +31,8 @@ jobs:
   codecoverage:
     needs: get-repo-name
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write       # Required for reusable codecoverage to push coverage HTML to gh-pages.
+      pull-requests: write  # Required for reusable codecoverage PR comments using secrets.repo_token.
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # Uses only github.repository in a shell echo; no checkout or github.token REST calls.
+    timeout-minutes: 5
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -33,6 +34,7 @@ jobs:
     permissions:
       contents: write       # Required for reusable codecoverage to push coverage HTML to gh-pages.
       pull-requests: write  # Required for reusable codecoverage PR comments using secrets.repo_token.
+    timeout-minutes: 90
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,6 @@ jobs:
     permissions:
       contents: read        # Required to clone this private repository with actions/checkout.
       pull-requests: read   # Required for technote-space/get-diff-action to read PR metadata for GIT_DIFF via the GitHub API.
-    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read        # Required to clone this private repository with actions/checkout.
       pull-requests: read   # Required for technote-space/get-diff-action to read PR metadata for GIT_DIFF via the GitHub API.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read        # Required to clone this private repository with actions/checkout.
+      pull-requests: read   # Required for technote-space/get-diff-action to read PR metadata for GIT_DIFF via the GitHub API.
     steps:
 
       - name: Checkout

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -22,8 +22,8 @@ jobs:
   prep-release:
     name: Prepare Release
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write       # Required for the reusable workflow to create release branches and commits.
+      pull-requests: write  # Required for the reusable workflow to open or update preparation pull requests.
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -21,10 +21,11 @@ jobs:
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
+    uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     permissions:
       contents: write       # Required for the reusable workflow to create release branches and commits.
-      pull-requests: write  # Required for the reusable workflow to open or update preparation pull requests.
-    uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
+      pull-requests: write # Required for the reusable workflow to open or update preparation pull requests.
+    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -25,7 +25,6 @@ jobs:
     permissions:
       contents: write       # Required for the reusable workflow to create release branches and commits.
       pull-requests: write # Required for the reusable workflow to open or update preparation pull requests.
-    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,7 +14,6 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # peter-evans/repository-dispatch uses secrets.WEBHOOK_TOKEN, not github.token, for the dispatch API call.
-    timeout-minutes: 10
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # peter-evans/repository-dispatch uses secrets.WEBHOOK_TOKEN, not github.token, for the dispatch API call.
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # peter-evans/repository-dispatch uses secrets.WEBHOOK_TOKEN, not github.token, for the dispatch API call.
+    timeout-minutes: 10
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 6 (`/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-notifications/.github/workflows/auto-translate.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-notifications/.github/workflows/brand-plugin-test-playwright.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-notifications/.github/workflows/codecoverage-main.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-notifications/.github/workflows/lint.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-notifications/.github/workflows/newfold-prep-release.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-notifications/.github/workflows/satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `b9e26fe` |
| Timeouts commit | `56bbdf5` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` |
| Workflows that were missing the required preceding comment block (added in this run): | `auto-translate.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| brand-plugin-test-playwright.yml | 3 jobs were missing a scoped `permissions:` directive | Setup | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 3 jobs were missing a scoped `permissions:` directive | Bluehost Build and Test Playwright | `contents: read` [3] |
| brand-plugin-test-playwright.yml | 3 jobs were missing a scoped `permissions:` directive | Bluehost DEV Build and Test Playwright | `contents: read` [3] |
| satis-update.yml | 1 job was missing a scoped `permissions:` directive | Send Webhook | `permissions: {}` [3] |
| lint.yml | 1 job was missing a scoped `permissions:` directive | Run PHP Code Sniffer | `contents: read`, `pull-requests: read` [3] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| auto-translate.yml | 0 jobs were missing a scoped `permissions:` directive (job permissions already present; comments aligned) | — | — |
| newfold-prep-release.yml | 0 jobs were missing a scoped `permissions:` directive (inline permission comments clarified) | — | — |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `brand-plugin-test-playwright.yml` :: workflow: BEFORE top-level `contents: read` -> AFTER `permissions: {}` with job-scoped grants -- default workflow permissions were broader than necessary; only reusable-call jobs need repository read for checkout -- [3] |
| 2 | `codecoverage-main.yml` :: workflow: BEFORE top-level `contents: read` -> AFTER `permissions: {}` with explicit per-job grants -- top-level read did not match least-privilege split across jobs (metadata-only job vs reusable codecoverage) -- [3] |
| 3 | `auto-translate.yml` :: workflow: BEFORE `permissions: {}` without required preceding comment block -> AFTER comment block + `permissions: {}` -- aligns with mandated workflow-root documentation pattern -- [3] |
| 4 | `codecoverage-main.yml` :: `codecoverage`: BEFORE `contents: write` / `pull-requests: write` without audit-style inline rationales -> AFTER same scopes with trailing inline comments -- documentation-only; scopes unchanged -- [3] |
| 5 | `auto-translate.yml` :: `translate`: BEFORE permissions without aligned inline rationales -> AFTER same scopes with aligned inline comments -- documentation-only; scopes unchanged -- [3] |
| 6 | `newfold-prep-release.yml` :: `prep-release`: BEFORE permissions without aligned inline rationales -> AFTER same scopes with aligned inline comments -- documentation-only; scopes unchanged -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| brand-plugin-test-playwright.yml | Setup | `5` | Branch-name extraction is trivial; a short cap prevents a stuck runner from burning minutes indefinitely. |
| brand-plugin-test-playwright.yml | Bluehost Build and Test Playwright | `60` | Brand-plugin Playwright reusable workflows typically run builds/tests that can exceed 30 minutes; 60 is a practical upper bound without matching GitHub’s default job timeout. |
| brand-plugin-test-playwright.yml | Bluehost DEV Build and Test Playwright | `60` | Same rationale as the primary Bluehost Playwright reusable call; separate artifact job still runs a full plugin test pipeline. |
| satis-update.yml | Send Webhook | `10` | Release tagging + repository dispatch should finish quickly; bounds accidental hangs while allowing for API latency. |
| lint.yml | Run PHP Code Sniffer | `30` | Composer install + PHPCS on a diff set is usually fast; 30 minutes is a safe ceiling for typical PR lint runs. |
| codecoverage-main.yml | get-repo-name | `5` | Single echo step; minimal timeout to cap runaway jobs. |
| codecoverage-main.yml | codecoverage | `90` | Reusable multi-PHP coverage aggregation, pages publishing, and PR commentary is materially heavier than linting; longer cap reduces false timeouts while still bounding runaway usage. |
| auto-translate.yml | Check and update translations | `30` | Translation automation may download/process catalogs and open/update PRs; 30 minutes is a standard safety bound for moderate automation jobs. |
| newfold-prep-release.yml | Prepare Release | `30` | Prep-release automation may create branches/PRs; 30 minutes is a reasonable default cap for release tooling. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Reusable workflows referenced from `newfold-labs/workflows` were not re-fetched end-to-end in this run; job permission assumptions are based on documented caller/callee patterns (`actions/checkout`, PR commenting, publishing artifacts) and should be revalidated if those reusable workflows change materially [2]. |


