### PR TITLE
Enable scheduled Dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Dependabot Auto-Merge
+on:
+  schedule:
+    # Two sweeps a day so a freshly-green (or freshly-rebased) Dependabot PR is
+    # merged within hours instead of waiting a full day. The sweep is cheap.
+    - cron: "0 6 * * *"
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Log what would be merged without merging.
+        type: boolean
+        default: false
+
+# Disable permissions for all scopes by default; grant only what the job needs.
+permissions: {}
+
+jobs:
+  # Delegates to the central reusable sweep in newfold-labs/workflows. It finds
+  # every open Dependabot PR and merges the eligible ones (not draft, mergeable,
+  # all check runs green, an opted-in bump type). Majors are left for a human.
+  auto-merge:
+    name: Auto-merge Dependabot PRs
+    uses: newfold-labs/workflows/.github/workflows/reusable-dependabot-auto-merge.yml@main
+    with:
+      merge-method: squash
+      update-types: patch,minor
+      dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
+    # checks: read lets the reusable read check-run status via the Checks API.
+    # GITHUB_TOKEN reaches the called workflow automatically — no secrets: inherit.
+    permissions:
+      contents: write
+      pull-requests: write
+      checks: read


### PR DESCRIPTION
Adds the scheduled Dependabot auto-merge caller (mirrors wp-module-mcp), pointing at the shared reusable in `newfold-labs/workflows@main`.

A twice-daily sweep merges eligible Dependabot PRs (not draft, mergeable, all checks green, patch/minor) using the repo's own `GITHUB_TOKEN` — no secrets. Majors stay individual for a human.

Updates are intentionally left **ungrouped**: with auto-merge handling the volume, keeping each update as its own PR means a CI failure is isolated to the exact dependency (and the rest still auto-merge) instead of a grouped batch you'd have to bisect.

Part of PRESS0-4266.
